### PR TITLE
ENG-107: Add Square provider support

### DIFF
--- a/src/paymcp/providers/__init__.py
+++ b/src/paymcp/providers/__init__.py
@@ -1,10 +1,12 @@
 from .stripe import StripeProvider
 from .walleot import WalleotProvider   
 from .adyen import AdyenProvider
+from .paypal import PayPalProvider
 
 PROVIDER_MAP = {
     "stripe": StripeProvider,
     "walleot": WalleotProvider,
+    "paypal": PayPalProvider,
     "adyen": AdyenProvider
 }
 

--- a/src/paymcp/providers/__init__.py
+++ b/src/paymcp/providers/__init__.py
@@ -2,12 +2,14 @@ from .stripe import StripeProvider
 from .walleot import WalleotProvider   
 from .adyen import AdyenProvider
 from .paypal import PayPalProvider
+from .square import SquareProvider
 
 PROVIDER_MAP = {
     "stripe": StripeProvider,
     "walleot": WalleotProvider,
     "paypal": PayPalProvider,
-    "adyen": AdyenProvider
+    "adyen": AdyenProvider,
+    "square": SquareProvider,
 }
 
 def build_providers(config: dict):

--- a/src/paymcp/providers/paypal.py
+++ b/src/paymcp/providers/paypal.py
@@ -1,0 +1,82 @@
+import requests
+from requests.auth import HTTPBasicAuth
+from .base import BasePaymentProvider
+import logging
+
+class PayPalProvider(BasePaymentProvider):
+    def __init__(self, 
+                client_id: str, 
+                client_secret: str, 
+                logger: logging.Logger = None,
+                success_url: str = "https://example.com/success",
+                cancel_url: str = "https://example.com/cancel", 
+                sandbox: bool = True):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.success_url = success_url
+        self.cancel_url = cancel_url
+        self.base_url = "https://api-m.sandbox.paypal.com" if sandbox else "https://api-m.paypal.com"
+        self._token = self._get_token()
+        super().__init__(logger=logger)
+        self.logger.debug("PayPal ready")
+
+    def _get_token(self):
+        """Get OAuth token from PayPal."""
+        resp = requests.post(
+            f"{self.base_url}/v1/oauth2/token",
+            auth=HTTPBasicAuth(self.client_id, self.client_secret),
+            data={"grant_type": "client_credentials"}
+        )
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+
+    def create_payment(self, amount: float, currency: str, description: str):
+        """Creates a PayPal checkout and returns (order_id, approval_url)."""
+        self.logger.debug(f"Creating PayPal payment: {amount} {currency} for '{description}'")
+        
+        headers = {"Authorization": f"Bearer {self._token}"}
+        payload = {
+            "intent": "CAPTURE",
+            "purchase_units": [{
+                "amount": {"currency_code": currency, "value": f"{amount:.2f}"},
+                "description": description
+            }],
+            "application_context": {
+                "return_url": self.success_url,
+                "cancel_url": self.cancel_url,
+                "user_action": "PAY_NOW"  # Critical: Shows "Pay Now" instead of "Continue"
+            }
+        }
+        
+        resp = requests.post(f"{self.base_url}/v2/checkout/orders", headers=headers, json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        
+        approve_url = next(link["href"] for link in data["links"] if link["rel"] == "approve")
+        return data["id"], approve_url
+
+    def get_payment_status(self, payment_id: str) -> str:
+        """Returns payment status, auto-capturing if approved."""
+        self.logger.debug(f"Checking PayPal payment status for: {payment_id}")
+        
+        headers = {"Authorization": f"Bearer {self._token}"}
+        resp = requests.get(f"{self.base_url}/v2/checkout/orders/{payment_id}", headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        
+        # Auto-capture approved payments
+        if data["status"] == "APPROVED":
+            try:
+                self.logger.debug(f"Auto-capturing payment: {payment_id}")
+                capture_resp = requests.post(
+                    f"{self.base_url}/v2/checkout/orders/{payment_id}/capture",
+                    headers=headers,
+                    json={}
+                )
+                capture_resp.raise_for_status()
+                return "paid" if capture_resp.json()["status"] == "COMPLETED" else "pending"
+            except Exception as e:
+                self.logger.error(f"Capture failed for {payment_id}: {e}")
+                return "pending"
+        
+        return "paid" if data["status"] == "COMPLETED" else "pending"

--- a/src/paymcp/providers/square.py
+++ b/src/paymcp/providers/square.py
@@ -1,0 +1,127 @@
+import requests
+from .base import BasePaymentProvider
+import logging
+import time
+import random
+import string
+
+SANDBOX_URL = "https://connect.squareupsandbox.com"
+PRODUCTION_URL = "https://connect.squareup.com"
+
+class SquareProvider(BasePaymentProvider):
+    def __init__(self, 
+                access_token: str,
+                location_id: str,
+                logger: logging.Logger = None,
+                redirect_url: str = 'https://example.com/success',
+                sandbox: bool = True):
+        self.access_token = access_token
+        self.location_id = location_id
+        self.redirect_url = redirect_url
+        self.base_url = SANDBOX_URL if sandbox else PRODUCTION_URL
+        super().__init__(logger=logger)
+        self.logger.debug("Square ready")
+
+    def _build_headers(self) -> dict:
+        """Square uses Bearer token authentication."""
+        return {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+            "Square-Version": "2024-01-18",  # Latest stable API version
+        }
+
+    def _generate_idempotency_key(self) -> str:
+        """Generate unique idempotency key for Square API calls."""
+        timestamp = str(int(time.time() * 1000))
+        random_str = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+        return f"{timestamp}-{random_str}"
+
+    def create_payment(self, amount: float, currency: str, description: str):
+        """Creates a Square Checkout and returns (checkout_id, checkout_url)."""
+        self.logger.debug(f"Creating Square payment: {amount} {currency} for '{description}'")
+        
+        # Convert to cents
+        amount_cents = int(amount * 100)
+        
+        idempotency_key = self._generate_idempotency_key()
+        
+        payload = {
+            "idempotency_key": idempotency_key,
+            "checkout": {
+                "order": {
+                    "order": {
+                        "location_id": self.location_id,
+                        "line_items": [
+                            {
+                                "name": description,
+                                "quantity": "1",
+                                "base_price_money": {
+                                    "amount": amount_cents,
+                                    "currency": currency.upper()
+                                }
+                            }
+                        ]
+                    },
+                    "idempotency_key": idempotency_key
+                },
+                "redirect_url": self.redirect_url
+            }
+        }
+        
+        resp = requests.post(
+            f"{self.base_url}/v2/locations/{self.location_id}/checkouts",
+            headers=self._build_headers(),
+            json=payload
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        
+        checkout = data.get("checkout", {})
+        checkout_id = checkout.get("id")
+        checkout_url = checkout.get("checkout_page_url")
+        
+        if not checkout_id or not checkout_url:
+            raise ValueError("Invalid response from Square API")
+        
+        return checkout_id, checkout_url
+
+    def get_payment_status(self, payment_id: str) -> str:
+        """Returns payment status for the given checkout_id."""
+        self.logger.debug(f"Checking Square payment status for: {payment_id}")
+        
+        try:
+            # First get the checkout to find the order
+            resp = requests.get(
+                f"{self.base_url}/v2/locations/{self.location_id}/checkouts/{payment_id}",
+                headers=self._build_headers()
+            )
+            resp.raise_for_status()
+            checkout_data = resp.json()
+            
+            order = checkout_data.get("checkout", {}).get("order", {})
+            order_id = order.get("id")
+            
+            if not order_id:
+                return "pending"
+            
+            # Now check the order status
+            order_resp = requests.get(
+                f"{self.base_url}/v2/orders/{order_id}?location_id={self.location_id}",
+                headers=self._build_headers()
+            )
+            order_resp.raise_for_status()
+            order_data = order_resp.json()
+            
+            order_state = order_data.get("order", {}).get("state", "")
+            
+            # Map Square order state to standard status
+            if order_state == "COMPLETED":
+                return "paid"
+            elif order_state == "CANCELED":
+                return "canceled"
+            else:
+                return "pending"
+                
+        except Exception as e:
+            self.logger.error(f"Error checking Square payment status: {e}")
+            return "pending"


### PR DESCRIPTION
## Summary
- Add Square payment provider with access token authentication
- Support for creating checkout sessions with redirect URLs
- Payment status checking via checkout and order APIs
- Configurable sandbox/production environments with proper API versioning

## Test plan
- [ ] Test Square provider initialization with access_token and location_id
- [ ] Verify payment creation returns checkout_id and checkout_url
- [ ] Test payment status checking for completed/canceled/pending states
- [ ] Validate sandbox and production mode switching
